### PR TITLE
fix: ignore `.eslintrc.*` config files when running eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,6 @@
     "plugins": ["jest", "@typescript-eslint"],
     "extends": ["plugin:github/recommended"],
     "parser": "@typescript-eslint/parser",
-    "root": true,
     "parserOptions": {
       "ecmaVersion": 9,
       "sourceType": "module",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
     "plugins": ["jest", "@typescript-eslint"],
     "extends": ["plugin:github/recommended"],
     "parser": "@typescript-eslint/parser",
+    "root": true,
     "parserOptions": {
       "ecmaVersion": 9,
       "sourceType": "module",

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -11,9 +11,9 @@ export async function runEslintOnPath(path: string) {
       encoding: 'utf8'
     }
   )
-  await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@latest')
+  await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@8')
   await execAsync(
-    `npx eslint@latest --no-ignore --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@8 --debug --no-ignore --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -8,9 +8,7 @@ export async function runEslintOnPath(path: string) {
     encoding: 'utf8'
   })
   await execAsync('npm i @fig/eslint-config-autocomplete')
-  await execAsync(
-    `npx eslint@8 --config .tmp-eslintrc --no-ignore --fix ${path}`
-  )
+  await execAsync(`npx eslint@8 --config .tmp-eslintrc --fix ${path}`)
   core.info('Finished running eslint on spec file')
 }
 

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -9,9 +9,7 @@ export async function runEslintOnPath(path: string) {
   })
   await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@latest')
   await execAsync(
-    `npx eslint ${
-      !path.endsWith('.ts') ? '--no-ignore' : ''
-    } --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@latest --no-ignore --debug --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -7,9 +7,11 @@ export async function runEslintOnPath(path: string) {
   await writeFile('.tmp-eslintrc', '{"extends":"@fig/autocomplete"}', {
     encoding: 'utf8'
   })
-  await execAsync('npm i @fig/eslint-config-autocomplete')
+  await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@latest')
   await execAsync(
-    `npx eslint@8 --no-ignore --config .tmp-eslintrc --fix ${path}`
+    `npx eslint ${
+      !path.endsWith('.ts') ? '--no-ignore' : ''
+    } --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -4,12 +4,16 @@ import { writeFile } from 'fs/promises'
 
 export async function runEslintOnPath(path: string) {
   core.info(`Started running eslint on spec file: ${path}`)
-  await writeFile('.tmp-eslintrc', '{"extends":"@fig/autocomplete"}', {
-    encoding: 'utf8'
-  })
+  await writeFile(
+    '.tmp-eslintrc',
+    '{"root": true,"extends":"@fig/autocomplete"}',
+    {
+      encoding: 'utf8'
+    }
+  )
   await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@latest')
   await execAsync(
-    `npx eslint@latest --debug --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@latest --no-ignore --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -9,7 +9,7 @@ export async function runEslintOnPath(path: string) {
   })
   await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@latest')
   await execAsync(
-    `npx eslint@latest --no-ignore --debug --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@latest --debug --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -13,7 +13,7 @@ async function runEslintOnPath(path: string) {
   )
   await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@8')
   await execAsync(
-    `npx eslint@8 --debug --no-ignore --no-eslintrc --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@8 --no-ignore --no-eslintrc --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -8,7 +8,9 @@ export async function runEslintOnPath(path: string) {
     encoding: 'utf8'
   })
   await execAsync('npm i @fig/eslint-config-autocomplete')
-  await execAsync(`npx eslint@8 --config .tmp-eslintrc --fix ${path}`)
+  await execAsync(
+    `npx eslint@8 --no-ignore --config .tmp-eslintrc --fix ${path}`
+  )
   core.info('Finished running eslint on spec file')
 }
 

--- a/src/lint-format.ts
+++ b/src/lint-format.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import { execAsync } from './utils'
 import { writeFile } from 'fs/promises'
 
-export async function runEslintOnPath(path: string) {
+async function runEslintOnPath(path: string) {
   core.info(`Started running eslint on spec file: ${path}`)
   await writeFile(
     '.tmp-eslintrc',
@@ -13,12 +13,12 @@ export async function runEslintOnPath(path: string) {
   )
   await execAsync('npm i @fig/eslint-config-autocomplete@latest eslint@8')
   await execAsync(
-    `npx eslint@8 --debug --no-ignore --config .tmp-eslintrc --fix ${path}`
+    `npx eslint@8 --debug --no-ignore --no-eslintrc --config .tmp-eslintrc --fix ${path}`
   )
   core.info('Finished running eslint on spec file')
 }
 
-export async function runPrettierOnPath(path: string) {
+async function runPrettierOnPath(path: string) {
   core.info(`Started running prettier on spec file: ${path}`)
   await execAsync(
     `npx prettier@2 ${path} --no-config --write --parser typescript`

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { uploadFilepathArtifact, uploadFolderPathArtifact } from './artifact'
 import { AutocompleteRepoManager } from './autocomplete-repo-manager'
 import { TMP_FOLDER } from './constants'
 import { getDefaultBranch } from './git-utils'
-import { lintAndFormatSpec, runEslintOnPath } from './lint-format'
+import { lintAndFormatSpec } from './lint-format'
 import { randomUUID } from 'crypto'
 
 async function run() {
@@ -97,7 +97,7 @@ async function run() {
         )} ${newSpecVersion} --cwd ${TMP_FOLDER}`
       )
 
-      await runEslintOnPath(path.resolve(TMP_FOLDER, autocompleteSpecName))
+      await lintAndFormatSpec(path.resolve(TMP_FOLDER, autocompleteSpecName))
 
       localSpecFileOrFolder = {
         repoPath: `src/${autocompleteSpecName}`,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**